### PR TITLE
Remove `window` from UMD definition

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'jahuty.js',
     library: 'jahuty',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: `(typeof self !== 'undefined' ? self : this)`
   },
   module: {
     rules: [


### PR DESCRIPTION
Try the recommended workaround by setting the `output.globalObject` config option.

Closes #9 