### PR TITLE
Fix error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.1.4 - 2020-11-02
+
+* Fix [#12](https://github.com/jahuty/jahuty-node/issues/13), stop swallowing exceptions during Axios request setup.
+
 ## 0.1.3 - 2020-09-26
 
 * Fix [#11](https://github.com/jahuty/jahuty-node/issues/11), other classes than `Jahuty` not available.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahuty/jahuty",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "dist/jahuty.js",
   "author": "",

--- a/src/jahuty.js
+++ b/src/jahuty.js
@@ -60,4 +60,4 @@ export default class Jahuty
 }
 
 Jahuty.ORIGIN  = 'https://api.jahuty.com'
-Jahuty.VERSION = '0.1.3'
+Jahuty.VERSION = '0.1.4'

--- a/src/snippet.js
+++ b/src/snippet.js
@@ -21,10 +21,16 @@ export default class Snippet
           throw new NotOk(Problem.from(error.response.data));
         } else if (error.request) {
           // The request was made but no response was received.
-
+          console.error(
+            `No response was received from Jahuty for the following request:\n`,
+            error.request
+          );
         } else {
           // Something happened in setting up the request.
-
+          console.error(
+            `Couldn't set up request to Jahuty for the following reason: \n`,
+            error
+          );
         }
       });
   }


### PR DESCRIPTION
Stop swallowing errors in `Snippet.render`.

Closes #13 