### PR TITLE
Change to accept and ignore extra attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 - 2020-02-27
+
+- Change resources to accept and silently ignore unknown attributes returned by the API to permit API evolution.
+
 ## 0.2.0 - 2020-01-28
 
 * Change from a static-based architecture (e.g., `Snippet.render(1)`) to an instance-based one (e.g., `jahuty.snippets.render(1)`) to make the library easier to develop, test, and use.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahuty/jahuty",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Jahuty's Node.js SDK",
   "main": "./lib/client.js",
   "author": [

--- a/src/jahuty.js
+++ b/src/jahuty.js
@@ -1,4 +1,4 @@
 export default class Jahuty {}
 
 Jahuty.BASE_URL = 'https://api.jahuty.com';
-Jahuty.VERSION = '0.2.0';
+Jahuty.VERSION = '0.2.1';

--- a/src/resource/factory.js
+++ b/src/resource/factory.js
@@ -10,6 +10,6 @@ export default class Factory {
       throw new TypeError('Action expected to be show render');
     }
 
-    return new Render.from(response.data);
+    return Render.from(response.data);
   }
 }

--- a/src/resource/factory.js
+++ b/src/resource/factory.js
@@ -10,6 +10,6 @@ export default class Factory {
       throw new TypeError('Action expected to be show render');
     }
 
-    return new Render(response.data);
+    return new Render.from(response.data);
   }
 }

--- a/src/resource/problem.js
+++ b/src/resource/problem.js
@@ -7,4 +7,24 @@ export default class Problem {
     this.type = type;
     this.detail = detail;
   }
+
+  static from(payload) {
+    if (!('status' in payload)) {
+      throw new Error("Payload missing 'status' key");
+    }
+
+    if (!('type' in payload)) {
+      throw new Error("Payload missing 'type' key");
+    }
+
+    if (!('detail' in payload)) {
+      throw new Error("Payload missing 'detail' key");
+    }
+
+    return new Problem({
+      status: payload.status,
+      type: payload.type,
+      detail: payload.detail,
+    });
+  }
 }

--- a/src/resource/render.js
+++ b/src/resource/render.js
@@ -6,6 +6,14 @@ export default class Render {
     this.content = content;
   }
 
+  static from(payload) {
+    if (!('content' in payload)) {
+      throw new Error("Payload missing 'content' key");
+    }
+
+    return new Render({ content: payload.content });
+  }
+
   toString() {
     return `${this.content}`;
   }

--- a/tests/resource/problem.test.js
+++ b/tests/resource/problem.test.js
@@ -24,4 +24,40 @@ describe('Problem', () => {
       expect(problem.type).toEqual(type);
     });
   });
+
+  describe('.from', () => {
+    let params;
+
+    beforeEach(() => {
+      params = { status: 1, type: 'foo', detail: 'bar' };
+    });
+
+    it('rasies error when status is missing', () => {
+      delete params.status;
+
+      expect(() => Problem.from(params)).toThrow(Error);
+    });
+
+    it('rasies error when type is missing', () => {
+      delete params.type;
+
+      expect(() => Problem.from(params)).toThrow(Error);
+    });
+
+    it('rasies error when detail is missing', () => {
+      delete params.detail;
+
+      expect(() => Problem.from(params)).toThrow(Error);
+    });
+
+    it('does not raise error when extra attribute is present', () => {
+      params.foo = 'bar';
+
+      expect(() => Problem.from(params)).not.toThrow(Error);
+    });
+
+    it('returns problem', () => {
+      expect(Problem.from(params)).toBeInstanceOf(Problem);
+    });
+  });
 });

--- a/tests/resource/render.test.js
+++ b/tests/resource/render.test.js
@@ -11,6 +11,30 @@ describe('Snippet', () => {
     });
   });
 
+  describe('.from', () => {
+    let params;
+
+    beforeEach(() => {
+      params = { content: 'foo' };
+    });
+
+    it('rasies error when content is missing', () => {
+      delete params.content;
+
+      expect(() => Render.from(params)).toThrow(Error);
+    });
+
+    it('does not rasie error when extra attribute is present', () => {
+      params.foo = 'bar';
+
+      expect(() => Render.from(params)).not.toThrow(Error);
+    });
+
+    it('returns snippet', () => {
+      expect(Render.from(params)).toBeInstanceOf(Render);
+    });
+  });
+
   describe('.toString()', () => {
     it('returns content', () => {
       expect(render.toString()).toEqual(content);


### PR DESCRIPTION
We should be able to add attributes to the API's response before utilizing them in our SDKs. Unfortunately, I broke that functionality in #20. I got too cute with keyword arguments, and I passed the returned JSON object straight to the resource's constructor. This doesn't allow for extra attributes. I fix.