### PR TITLE
Fix ttl and collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 - 2020-03-14
+
+### Added
+
+- Added support for zero and negative `ttl` values to disable cache.
+- Added system tests for cached, parameterized, and tagged snippets.
+
+### Fixed
+
+- Fixed bad build in NPM because Jack forgot to build before release :(
+- Fixed issue with the `allRenders()` method not sending query string parameters.
+
 ## 0.3.0 - 2021-03-13
 
 - Fixed issue where the `render` method's `params` were not being json-encoded properly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahuty/jahuty",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Jahuty's Node.js SDK",
   "main": "./lib/client.js",
   "author": [

--- a/src/jahuty.js
+++ b/src/jahuty.js
@@ -1,4 +1,4 @@
 export default class Jahuty {}
 
 Jahuty.BASE_URL = 'https://api.jahuty.com';
-Jahuty.VERSION = '0.3.0';
+Jahuty.VERSION = '0.3.1';

--- a/src/service/snippet.js
+++ b/src/service/snippet.js
@@ -20,18 +20,20 @@ export default class Snippet extends Base {
 
   async allRenders(tag, options = {}) {
     const params = 'params' in options ? options.params : {};
-
     const ttl = 'ttl' in options ? options.ttl : this.ttl;
 
     const renders = await this.indexRenders({ tag, params });
 
-    this.cacheRenders({ renders, params, ttl });
+    if (ttl === null || ttl > 0) {
+      this.cacheRenders({ renders, params, ttl });
+    }
 
     return renders;
   }
 
   async render(snippetId, options = {}) {
     const params = 'params' in options ? options.params : {};
+    const ttl = 'ttl' in options ? options.ttl : this.ttl;
 
     const key = Snippet.getRenderCacheKey({ snippetId, params });
 
@@ -51,9 +53,9 @@ export default class Snippet extends Base {
 
       render = this.client.request(action);
 
-      const ttl = 'ttl' in options ? options.ttl : this.ttl;
-
-      this.cache.set(key, render, ttl);
+      if (ttl === null || ttl > 0) {
+        this.cache.set(key, render, ttl);
+      }
     }
 
     return render;

--- a/src/service/snippet.js
+++ b/src/service/snippet.js
@@ -91,13 +91,13 @@ export default class Snippet extends Base {
   }
 
   async indexRenders({ tag, params }) {
-    const reqParams = { tag };
+    const requestParams = { tag };
 
     if (params !== null) {
-      reqParams.params = JSON.stringify(params);
+      requestParams.params = JSON.stringify(params);
     }
 
-    const action = new Index({ resource: 'render', reqParams });
+    const action = new Index({ resource: 'render', params: requestParams });
 
     const renders = await this.client.request(action);
 

--- a/tests/system.test.js
+++ b/tests/system.test.js
@@ -26,13 +26,13 @@ describe('System', () => {
     it('renders the snippet', async () => {
       const params = { foo: 'foo', bar: 'bar' };
 
-      const render = await jahuty.snippets.render(62, { params: params });
+      const render = await jahuty.snippets.render(62, { params });
 
       expect(render.content).toBe(render62.content);
 
       // A second render with the same params should use the cached value.
       let start = new Date();
-      await jahuty.snippets.render(62, { params: params });
+      await jahuty.snippets.render(62, { params });
       let end = new Date();
 
       expect(end.getTime() - start.getTime()).toBeLessThan(5);
@@ -41,7 +41,7 @@ describe('System', () => {
       params.bar = 'baz';
 
       start = new Date();
-      await jahuty.snippets.render(62, { params: params });
+      await jahuty.snippets.render(62, { params });
       end = new Date();
 
       expect(end.getTime() - start.getTime()).toBeGreaterThan(5);
@@ -52,7 +52,7 @@ describe('System', () => {
     it('renders the snippets', async () => {
       // This request should return two renders.
       const renders = await jahuty.snippets.allRenders('test', {
-        params: { '*': { foo: 'foo' }, '62': { bar: 'bar' } }
+        params: { '*': { foo: 'foo' }, 62: { bar: 'bar' } },
       });
 
       expect(renders).toHaveLength(2);

--- a/tests/system.test.js
+++ b/tests/system.test.js
@@ -2,14 +2,77 @@ import Client from '../src/client';
 
 describe('System', () => {
   const apiKey = 'kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc';
-  const content = '<p>This is my first snippet!</p>';
   const jahuty = new Client({ apiKey });
 
-  describe('when the user renders a snippet', () => {
-    it('returns render', async () => {
+  const render1 = { snippetId: 1, content: '<p>This is my first snippet!</p>' };
+  const render62 = { snippetId: 62, content: '<p>This foo is bar.</p>' };
+
+  describe('when the user renders a static snippet', () => {
+    it('renders the snippet', async () => {
       const render = await jahuty.snippets.render(1);
 
-      expect(render).toMatchObject({ content });
+      expect(render.content).toBe(render1.content);
+
+      // A second render should use the cached value.
+      const start = new Date().getTime();
+      await jahuty.snippets.render(1);
+      const end = new Date().getTime();
+
+      expect(end - start).toBeLessThan(5);
+    });
+  });
+
+  describe('when the user renders a parameterized snippet', () => {
+    it('renders the snippet', async () => {
+      const params = { foo: 'foo', bar: 'bar' };
+
+      const render = await jahuty.snippets.render(62, { params: params });
+
+      expect(render.content).toBe(render62.content);
+
+      // A second render with the same params should use the cached value.
+      let start = new Date();
+      await jahuty.snippets.render(62, { params: params });
+      let end = new Date();
+
+      expect(end.getTime() - start.getTime()).toBeLessThan(5);
+
+      // A third render with different params should render the snippet.
+      params.bar = 'baz';
+
+      start = new Date();
+      await jahuty.snippets.render(62, { params: params });
+      end = new Date();
+
+      expect(end.getTime() - start.getTime()).toBeGreaterThan(5);
+    });
+  });
+
+  describe('when the user renders many snippets', () => {
+    it('renders the snippets', async () => {
+      // This request should return two renders.
+      const renders = await jahuty.snippets.allRenders('test', {
+        params: { '*': { foo: 'foo' }, '62': { bar: 'bar' } }
+      });
+
+      expect(renders).toHaveLength(2);
+      expect(renders).toContainEqual(render1);
+      expect(renders).toContainEqual(render62);
+
+      // A call to render a snippet in the collection should use the cached value.
+      let start = new Date();
+      await jahuty.snippets.render(1);
+      let end = new Date();
+
+      expect(end.getTime() - start.getTime()).toBeLessThan(5);
+
+      // A call to render a snippet in the collection with the equivalent params
+      // should use the cached value.
+      start = new Date();
+      await jahuty.snippets.render(62, { params: { foo: 'foo', bar: 'bar' } });
+      end = new Date();
+
+      expect(end.getTime() - start.getTime()).toBeLessThan(5);
     });
   });
 });


### PR DESCRIPTION
Fix support for negative and zero `ttl` values; fix issue where `allRenders()` did not send query string parameters; fix the bad build in NPM; and, add system tests for cached, parameterized, and tagged snippets.