### PR TITLE
Fix caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.1 - 2020-03-14
+## 0.3.2 - 2021-04-23
+
+### Fixed
+
+- Fixed issue [#26](https://github.com/jahuty/jahuty-node/issues/26), where `render()` cached the `Promise`, not the `Render`.
+
+## 0.3.1 - 2021-03-14
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahuty/jahuty",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Jahuty's Node.js SDK",
   "main": "./lib/client.js",
   "author": [

--- a/src/jahuty.js
+++ b/src/jahuty.js
@@ -1,4 +1,4 @@
 export default class Jahuty {}
 
 Jahuty.BASE_URL = 'https://api.jahuty.com';
-Jahuty.VERSION = '0.3.1';
+Jahuty.VERSION = '0.3.2';

--- a/src/service/snippet.js
+++ b/src/service/snippet.js
@@ -51,7 +51,7 @@ export default class Snippet extends Base {
         params: requestParams,
       });
 
-      render = this.client.request(action);
+      render = await this.client.request(action);
 
       if (ttl === null || ttl > 0) {
         this.cache.set(key, render, ttl);

--- a/tests/system.test.js
+++ b/tests/system.test.js
@@ -9,16 +9,18 @@ describe('System', () => {
 
   describe('when the user renders a static snippet', () => {
     it('renders the snippet', async () => {
-      const render = await jahuty.snippets.render(1);
+      let render = await jahuty.snippets.render(1);
 
       expect(render.content).toBe(render1.content);
 
       // A second render should use the cached value.
       const start = new Date().getTime();
-      await jahuty.snippets.render(1);
+      render = await jahuty.snippets.render(1);
       const end = new Date().getTime();
 
       expect(end - start).toBeLessThan(5);
+      // Verify the content is correct (see #26 for details).
+      expect(render.content).toBe(render1.content);
     });
   });
 


### PR DESCRIPTION
It looks like the `render()` method was caching the `Promise`, not the `render`. When the `Promise` eventually resolved, the value stored in the cache was `{}`, and the value of `{}.content` is `undefined`.

I fixed the code and added an assertion to the system tests (the service tests mock the cache).

Closes #26 