### PR TITLE
Add latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 - 2021-04-30
+
+### Added
+
+- Added `preferLatest` flag to client and render methods. This option allows you to render a snippet's _latest_ content instead of the default _published_ content.
+
 ## 0.3.2 - 2021-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ const renders = await jahuty.snippets.allRenders('YOUR_TAG');
 renders.forEach((render) => console.log(render));
 ```
 
+## Rendering content
+
+You can configure this library to render a snippet's _latest_ content to your team in _development_ and its _published_ content to your customers in _production_.
+
+By default, Jahuty will render a snippet's _published_ content, the content that existed the last time a teammate clicked the "Publish" button, to avoid exposing your creative process to customers.
+
+To render a snippet's _latest_ content, the content that currently exists in the editor, in the current environment use the `preferLatest` configuration option at the library or render level:
+
+```js
+const Client = require('@jahuty/jahuty').default;
+
+const jahuty = new Client({ apiKey: YOUR_API_KEY, preferLatest: true });
+```
+
+You can also prefer the latest content (or not) for a single render:
+
+```js
+const Client = require('@jahuty/jahuty').default;
+
+const jahuty = new Client({ apiKey: YOUR_API_KEY });
+
+const render = await jahuty.snippets.render(YOUR_SNIPPET_ID, { preferLatest: true });
+```
+
 ## Using parameters
 
 You can [pass parameters](https://docs.jahuty.com/liquid/parameters) into your snippet using the options hash and the params key:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahuty/jahuty",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Jahuty's Node.js SDK",
   "main": "./lib/client.js",
   "author": [

--- a/src/client.js
+++ b/src/client.js
@@ -8,15 +8,21 @@ import ResourceFactory from './resource/factory';
 import 'regenerator-runtime/runtime';
 
 export default class Client {
-  constructor({ apiKey, cache = null, ttl = null }) {
+  constructor({ apiKey, cache = null, ttl = null, preferLatest = false }) {
     this.apiKey = apiKey;
     this.cache = cache || new Keyv({ namespace: 'jahuty' });
     this.ttl = ttl;
+    this.preferLatest = preferLatest;
   }
 
   get snippets() {
     if (this.services === undefined) {
-      this.services = new Snippet({ client: this, cache: this.cache, ttl: this.ttl });
+      this.services = new Snippet({
+        client: this,
+        cache: this.cache,
+        ttl: this.ttl,
+        preferLatest: this.preferLatest,
+      });
     }
 
     return this.services;

--- a/src/client.js
+++ b/src/client.js
@@ -8,7 +8,12 @@ import ResourceFactory from './resource/factory';
 import 'regenerator-runtime/runtime';
 
 export default class Client {
-  constructor({ apiKey, cache = null, ttl = null, preferLatest = false }) {
+  constructor({
+    apiKey,
+    cache = null,
+    ttl = null,
+    preferLatest = false,
+  }) {
     this.apiKey = apiKey;
     this.cache = cache || new Keyv({ namespace: 'jahuty' });
     this.ttl = ttl;

--- a/src/jahuty.js
+++ b/src/jahuty.js
@@ -1,4 +1,4 @@
 export default class Jahuty {}
 
 Jahuty.BASE_URL = 'https://api.jahuty.com';
-Jahuty.VERSION = '0.3.2';
+Jahuty.VERSION = '0.4.0';

--- a/src/service/snippet.js
+++ b/src/service/snippet.js
@@ -11,23 +11,24 @@ import 'regenerator-runtime/runtime';
  * Executes requests on snippet resources.
  */
 export default class Snippet extends Base {
-  constructor({ client, cache, ttl = null }) {
+  constructor({ client, cache, ttl = null, preferLatest = false }) {
     super({ client });
 
     this.cache = cache;
     this.ttl = ttl;
+    this.preferLatest = preferLatest;
   }
 
   async allRenders(tag, options = {}) {
     const params = 'params' in options ? options.params : {};
     const ttl = 'ttl' in options ? options.ttl : this.ttl;
-    const latest = 'preferLatest' in options ? options.preferLatest : false;
+    const preferLatest = 'preferLatest' in options ? options.preferLatest : false;
 
     const requestParams = { tag };
     if (params !== null) {
       requestParams.params = JSON.stringify(params);
     }
-    if (latest) {
+    if (preferLatest || this.preferLatest) {
       requestParams.latest = 1;
     }
 
@@ -45,7 +46,7 @@ export default class Snippet extends Base {
   async render(snippetId, options = {}) {
     const params = 'params' in options ? options.params : {};
     const ttl = 'ttl' in options ? options.ttl : this.ttl;
-    const latest = 'preferLatest' in options ? options.preferLatest : false;
+    const preferLatest = 'preferLatest' in options ? options.preferLatest : false;
 
     const key = Snippet.getRenderCacheKey({ snippetId, params });
 
@@ -56,7 +57,7 @@ export default class Snippet extends Base {
       if (params) {
         requestParams.params = JSON.stringify(params);
       }
-      if (latest) {
+      if (preferLatest || preferLatest) {
         requestParams.latest = 1;
       }
 

--- a/src/service/snippet.js
+++ b/src/service/snippet.js
@@ -34,6 +34,7 @@ export default class Snippet extends Base {
   async render(snippetId, options = {}) {
     const params = 'params' in options ? options.params : {};
     const ttl = 'ttl' in options ? options.ttl : this.ttl;
+    const latest = 'preferLatest' in options ? options.preferLatest : false;
 
     const key = Snippet.getRenderCacheKey({ snippetId, params });
 
@@ -43,6 +44,9 @@ export default class Snippet extends Base {
       const requestParams = {};
       if (params) {
         requestParams.params = JSON.stringify(params);
+      }
+      if (latest) {
+        requestParams.latest = 1;
       }
 
       const action = new Show({

--- a/src/service/snippet.js
+++ b/src/service/snippet.js
@@ -11,7 +11,12 @@ import 'regenerator-runtime/runtime';
  * Executes requests on snippet resources.
  */
 export default class Snippet extends Base {
-  constructor({ client, cache, ttl = null, preferLatest = false }) {
+  constructor({
+    client,
+    cache,
+    ttl = null,
+    preferLatest = false,
+  }) {
     super({ client });
 
     this.cache = cache;

--- a/tests/service/snippet.test.js
+++ b/tests/service/snippet.test.js
@@ -1,6 +1,7 @@
 import Keyv from 'keyv';
 
 import Client from '../../src/client';
+import Index from '../../src/action/index';
 import Show from '../../src/action/show';
 import Snippet from '../../src/service/snippet';
 import Render from '../../src/resource/render';
@@ -96,6 +97,29 @@ describe('Snippet', () => {
         await service.allRenders('foo');
 
         expect(cache.set.mock.calls).toHaveLength(1);
+      });
+    });
+
+    describe('when preferLatest does exist', () => {
+      const cache = new Keyv();
+
+      const client = new Client({ apiKey: 'foo' });
+      client.request.mockResolvedValue([
+        new Render({ snippetId: 1, content: 'foo' }),
+      ]);
+
+      const service = new Snippet({ client, cache });
+
+      beforeEach(async () => await service.allRenders('foo', { preferLatest: true }));
+
+      it('requests action', () => {
+        expect(client.request.mock.calls).toHaveLength(1);
+      });
+
+      it('has latest flag', () => {
+        const action = new Index({ resource: 'render', params: { latest: 1 } });
+
+        expect(client.request.mock.calls[0][0]).toMatchObject(action);
       });
     });
   });
@@ -197,7 +221,7 @@ describe('Snippet', () => {
       });
     });
 
-    describe('with preferLatest', () => {
+    describe('when preferLatest exists', () => {
       // mock a cache miss
       const cache = new Keyv();
       const client = new Client({ apiKey: 'foo' });

--- a/tests/service/snippet.test.js
+++ b/tests/service/snippet.test.js
@@ -110,7 +110,7 @@ describe('Snippet', () => {
 
       const service = new Snippet({ client, cache });
 
-      beforeEach(async () => await service.allRenders('foo', { preferLatest: true }));
+      beforeEach(async () => service.allRenders('foo', { preferLatest: true }));
 
       it('requests action', () => {
         expect(client.request.mock.calls).toHaveLength(1);

--- a/tests/service/snippet.test.js
+++ b/tests/service/snippet.test.js
@@ -196,6 +196,25 @@ describe('Snippet', () => {
         expect(client.request.mock.calls[0][0]).toMatchObject(action);
       });
     });
+
+    describe('with preferLatest', () => {
+      // mock a cache miss
+      const cache = new Keyv();
+      const client = new Client({ apiKey: 'foo' });
+      const service = new Snippet({ client, cache });
+
+      beforeEach(async () => { await service.render(1, { preferLatest: true }); });
+
+      it('requests action', () => {
+        expect(client.request.mock.calls).toHaveLength(1);
+      });
+
+      it('has latest flag', () => {
+        const action = new Show({ id: 1, resource: 'render', params: { latest: 1 } });
+
+        expect(client.request.mock.calls[0][0]).toMatchObject(action);
+      });
+    });
   });
 
   describe('::getRenderCacheKey', () => {

--- a/tests/system.test.js
+++ b/tests/system.test.js
@@ -7,74 +7,96 @@ describe('System', () => {
   const render1 = { snippetId: 1, content: '<p>This is my first snippet!</p>' };
   const render62 = { snippetId: 62, content: '<p>This foo is bar.</p>' };
 
-  describe('when the user renders a static snippet', () => {
-    it('renders the snippet', async () => {
-      let render = await jahuty.snippets.render(1);
+  const publishedRender102 = { snippetId: 102, content: '<p>This content is published.</p>' }
+  const latestRender102 = { snippetId: 102, content: '<p>This content is latest.</p>' }
 
-      expect(render.content).toBe(render1.content);
+  describe('user renders one snippet' , () => {
+    describe('with a static snippet', () => {
+      it('renders the snippet', async () => {
+        let render = await jahuty.snippets.render(1);
 
-      // A second render should use the cached value.
-      const start = new Date().getTime();
-      render = await jahuty.snippets.render(1);
-      const end = new Date().getTime();
+        expect(render.content).toBe(render1.content);
 
-      expect(end - start).toBeLessThan(5);
-      // Verify the content is correct (see #26 for details).
-      expect(render.content).toBe(render1.content);
-    });
-  });
+        // A second render should use the cached value.
+        const start = new Date().getTime();
+        render = await jahuty.snippets.render(1);
+        const end = new Date().getTime();
 
-  describe('when the user renders a parameterized snippet', () => {
-    it('renders the snippet', async () => {
-      const params = { foo: 'foo', bar: 'bar' };
-
-      const render = await jahuty.snippets.render(62, { params });
-
-      expect(render.content).toBe(render62.content);
-
-      // A second render with the same params should use the cached value.
-      let start = new Date();
-      await jahuty.snippets.render(62, { params });
-      let end = new Date();
-
-      expect(end.getTime() - start.getTime()).toBeLessThan(5);
-
-      // A third render with different params should render the snippet.
-      params.bar = 'baz';
-
-      start = new Date();
-      await jahuty.snippets.render(62, { params });
-      end = new Date();
-
-      expect(end.getTime() - start.getTime()).toBeGreaterThan(5);
-    });
-  });
-
-  describe('when the user renders many snippets', () => {
-    it('renders the snippets', async () => {
-      // This request should return two renders.
-      const renders = await jahuty.snippets.allRenders('test', {
-        params: { '*': { foo: 'foo' }, 62: { bar: 'bar' } },
+        expect(end - start).toBeLessThan(5);
+        // Verify the content is correct (see #26 for details).
+        expect(render.content).toBe(render1.content);
       });
+    });
 
-      expect(renders).toHaveLength(2);
-      expect(renders).toContainEqual(render1);
-      expect(renders).toContainEqual(render62);
+    describe('with parameters', () => {
+      it('renders the snippet', async () => {
+        const params = { foo: 'foo', bar: 'bar' };
 
-      // A call to render a snippet in the collection should use the cached value.
-      let start = new Date();
-      await jahuty.snippets.render(1);
-      let end = new Date();
+        const render = await jahuty.snippets.render(62, { params });
 
-      expect(end.getTime() - start.getTime()).toBeLessThan(5);
+        expect(render.content).toBe(render62.content);
 
-      // A call to render a snippet in the collection with the equivalent params
-      // should use the cached value.
-      start = new Date();
-      await jahuty.snippets.render(62, { params: { foo: 'foo', bar: 'bar' } });
-      end = new Date();
+        // A second render with the same params should use the cached value.
+        let start = new Date();
+        await jahuty.snippets.render(62, { params });
+        let end = new Date();
 
-      expect(end.getTime() - start.getTime()).toBeLessThan(5);
+        expect(end.getTime() - start.getTime()).toBeLessThan(5);
+
+        // A third render with different params should render the snippet.
+        params.bar = 'baz';
+
+        start = new Date();
+        await jahuty.snippets.render(62, { params });
+        end = new Date();
+
+        expect(end.getTime() - start.getTime()).toBeGreaterThan(5);
+      });
+    });
+
+    describe('with latest content', () => {
+      it('renders the snippets', async () => {
+        const render = await jahuty.snippets.render(102, { preferLatest: true });
+
+        expect(render).toEqual(latestRender102);
+      });
+    });
+  });
+
+  describe('user renders many snippets', () => {
+    describe('with parameters', () => {
+      it('renders the snippets', async () => {
+        const renders = await jahuty.snippets.allRenders('test', {
+          params: { '*': { foo: 'foo' }, 62: { bar: 'bar' } },
+        });
+
+        expect(renders).toContainEqual(render1);
+        expect(renders).toContainEqual(render62);
+        expect(renders).toContainEqual(publishedRender102);
+
+        // A call to render a snippet in the collection should use the cached value.
+        let start = new Date();
+        await jahuty.snippets.render(1);
+        let end = new Date();
+
+        expect(end.getTime() - start.getTime()).toBeLessThan(5);
+
+        // A call to render a snippet in the collection with the equivalent params
+        // should use the cached value.
+        start = new Date();
+        await jahuty.snippets.render(62, { params: { foo: 'foo', bar: 'bar' } });
+        end = new Date();
+
+        expect(end.getTime() - start.getTime()).toBeLessThan(5);
+      });
+    });
+
+    describe('with latest content', () => {
+      it('renders the snippets', async () => {
+        const renders = await jahuty.snippets.allRenders('test', { preferLatest: true });
+
+        expect(renders).toContainEqual(latestRender102);
+      });
     });
   });
 });

--- a/tests/system.test.js
+++ b/tests/system.test.js
@@ -7,10 +7,10 @@ describe('System', () => {
   const render1 = { snippetId: 1, content: '<p>This is my first snippet!</p>' };
   const render62 = { snippetId: 62, content: '<p>This foo is bar.</p>' };
 
-  const publishedRender102 = { snippetId: 102, content: '<p>This content is published.</p>' }
-  const latestRender102 = { snippetId: 102, content: '<p>This content is latest.</p>' }
+  const publishedRender102 = { snippetId: 102, content: '<p>This content is published.</p>' };
+  const latestRender102 = { snippetId: 102, content: '<p>This content is latest.</p>' };
 
-  describe('user renders one snippet' , () => {
+  describe('user renders one snippet', () => {
     describe('with a static snippet', () => {
       it('renders the snippet', async () => {
         let render = await jahuty.snippets.render(1);


### PR DESCRIPTION
Add the `preferLatest` option to the client and render methods to render a snippet's  _latest_ content, instead of its default _published_ content.